### PR TITLE
Fix UnescaeWideChar in encoding.cc

### DIFF
--- a/src/sdk/encoding/encoding.cc
+++ b/src/sdk/encoding/encoding.cc
@@ -357,6 +357,11 @@ std::wstring UnescapeWideChar(const std::wstring &wstr_with_ucs2, const std::wst
                                     wstr += wch;
                                     continue;
                                 }
+                                else
+                                {
+                                    wstr += ucs2_tmp;
+                                    continue;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
修复如下问题:
消息中[字符\u005b处理后多一个b字符:\u005bb
消息中]字符\u005d处理后多一个d字符:\u005dd
消息中\字符\u005c处理后多一个c字符:\u005cc